### PR TITLE
Update About_JapanWG.md

### DIFF
--- a/About_Japan-wg/About_JapanWG.md
+++ b/About_Japan-wg/About_JapanWG.md
@@ -55,9 +55,8 @@
 ## 関連情報
 * OpenChain project:
   * Website: https://www.openchainproject.org/
-  * Wiki: https://wiki.linuxfoundation.org/openchain/start
   * GitHub: https://github.com/OpenChain-Project
-  * ML: openchain@lists.linuxfoundation.org
+  * ML: main@lists.openchainproject.org
   * Translations: https://www.openchainproject.org/translations
 
 * Japan WG:


### PR DESCRIPTION
前回、日本関連の部分の更新を提案しましたが、今回はそのOpenChain本体版です。
Wikiは相当するものを見つけられなかったので（GitHubを書くのもありかと思いましたが、GitHubはGitHubですでに項目としてありますし、、、、）単に削除してみました。