### PR TITLE
update links for materials

### DIFF
--- a/docs/subgroups/licensing/index.md
+++ b/docs/subgroups/licensing/index.md
@@ -41,8 +41,8 @@ Fumiko Ito / 伊藤 文子
 
 - [&#x1f4c2; SPDX Lite Overview](https://github.com/OpenChain-Project/OpenChain-JWG/blob/master/subgroups/licensing/outcomes/spdx-lite-overview-20190829.pdf)  
 - [&#x1f4c2; proposal of SPDX Lite](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/Proposal)  
-- [&#x1f4c2; Guideline of SPDX Lite](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/Guideline)  
-- [&#x1f4c2; sample of SPDX Lite](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/SPDX-Lite-sample)  
+- [&#x1f4c2; Guideline of SPDX Lite](https://github.com/OpenChain-Project/OpenChain-JWG/tree/master/License-Info-Exchange/Guideline)
+- [&#x1f4c2; sample of SPDX Lite](https://github.com/OpenChain-Project/OpenChain-JWG/tree/master/License-Info-Exchange/SPDX-Lite-sample)
 - [&#x1f4c2; (sample for reference)Actual SPDX file](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/SPDX-file)  
 
 ---


### PR DESCRIPTION
リンク先をJapan-WG-GeneralからOpenChain-JWGに切り替え