### PR TITLE
update URL of 'Japan-WG-General' to 'OpenChain-JWG'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenChain-JWG
 
-## This repository provides the outcomes of the [OpenChain Japan work group](https://github.com/OpenChain-Project/Japan-WG-General).
+## This repository provides the outcomes of the [OpenChain Japan work group](https://openchain-project.github.io/OpenChain-JWG/index_en.html).
 
  We'll share the outcomes in this repository and here's a current list.
 
@@ -38,7 +38,7 @@ or
 ---
 ---
 
-## このリポジトリでは[OpenChain Japan Work Group](https://github.com/OpenChain-Project/Japan-WG-General)の成果物を提供します
+## このリポジトリでは[OpenChain Japan Work Group](https://openchain-project.github.io/OpenChain-JWG/index.html)の成果物を提供します
 
 作業成果物をこのリポジトリで管理しています。現状では以下のような資料があります。
 

--- a/docs/outcomes.md
+++ b/docs/outcomes.md
@@ -21,9 +21,9 @@
 SPDX Lite (Japan work group is thinking a new proposal of SPDX Lite, minimum license information to exchange between comapnies.)
 
 - [&#x1f4da; SPDX Lite Overview](https://github.com/OpenChain-Project/OpenChain-JWG/blob/master/subgroups/licensing/outcomes/spdx-lite-overview-20190829.pdf)  
-- [&#x1f4c2; proposal of SPDX Lite](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/Proposal)  
-- [&#x1f4c2; sample of SPDX Lite](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/SPDX-Lite-sample)  
-- [&#x1f4c2; (sample for reference) Actual SPDX file](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/SPDX-file)  
+- [&#x1f4c2; proposal of SPDX Lite](https://github.com/OpenChain-Project/OpenChain-JWG/tree/master/License-Info-Exchange/SPDX-Lite/Proposal-of-SPDX-Lite.md)
+- [&#x1f4c2; sample of SPDX Lite](https://github.com/OpenChain-Project/OpenChain-JWG/tree/master/License-Info-Exchange/SPDX-Lite/sample)
+- [&#x1f4c2; (sample for reference) Actual SPDX file](https://github.com/OpenChain-Project/OpenChain-JWG/tree/master/License-Info-Exchange/Reference/spdx-rcar_h3.tar.bz2)
 
 ---
 

--- a/docs/outcomes_en.md
+++ b/docs/outcomes_en.md
@@ -18,9 +18,9 @@
 SPDX Lite (Japan work group is thinking a new proposal of SPDX Lite, minimum license information to exchange between comapnies.)
 
 - [&#x1f4da; SPDX Lite Overview](https://github.com/OpenChain-Project/OpenChain-JWG/blob/master/subgroups/licensing/outcomes/spdx-lite-overview-20190829.pdf)  
-- [&#x1f4c2; proposal of SPDX Lite](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/Proposal)  
-- [&#x1f4c2; sample of SPDX Lite](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/SPDX-Lite-sample)  
-- [&#x1f4c2; (sample for reference)Actual SPDX file](https://github.com/OpenChain-Project/Japan-WG-General/tree/master/License-Info-Exchange/SPDX-file)  
+- [&#x1f4c2; proposal of SPDX Lite](https://github.com/OpenChain-Project/OpenChain-JWG/tree/master/License-Info-Exchange/SPDX-Lite/Proposal-of-SPDX-Lite.md)
+- [&#x1f4c2; sample of SPDX Lite](https://github.com/OpenChain-Project/OpenChain-JWG/tree/master/License-Info-Exchange/SPDX-Lite/sample)
+- [&#x1f4c2; (sample for reference) Actual SPDX file](https://github.com/OpenChain-Project/OpenChain-JWG/tree/master/License-Info-Exchange/Reference/spdx-rcar_h3.tar.bz2)
 
 ---
 


### PR DESCRIPTION
Japan-WG-Generalにリンクしていたものを切り替えています。