### PR TITLE
fix typos

### DIFF
--- a/docs/upcoming-events.md
+++ b/docs/upcoming-events.md
@@ -1,7 +1,7 @@
 #### The 26th meeting / The 13th Virtual meeting
 
-第25回全体会合／第12回オンラインは10/13に無事開催されました。参加してくださった皆さん、ありがとうございました。/ Thank you for your joining the 25th meeting / the 12th Virtual meeting.
+第25回全体会合／第12回オンラインは10/31に無事開催されました。参加してくださった皆さん、ありがとうございました。/ Thank you for your joining the 25th meeting / the 12th Virtual meeting.
 
-次回の全体会合は年明けなるでしょうか。お楽しみに！ / We are planning the next meeting in around the beginning of the next year.  Stay tuned!
+次回の全体会合は年明け頃になるでしょうか。お楽しみに！ / We are planning the next meeting in around the beginning of the next year.  Stay tuned!
 
 *`looking for past meeting logs?`* → [日本語/Japanese](https://openchain-project.github.io/OpenChain-JWG/meeting-minutes.html), [英語/English](https://openchain-project.github.io/OpenChain-JWG/meeting-minutes_en.html)  


### PR DESCRIPTION
公開されてから誤記・誤字脱字に気づくという典型的な悪い例です。
良い子はマネしないように