### PR TITLE
fix typo in automation SG desc

### DIFF
--- a/docs/subgroups/tooling/upcoming-events.md
+++ b/docs/subgroups/tooling/upcoming-events.md
@@ -2,6 +2,6 @@
 
 発表希望の方は、Automation-SGのMLかSlackでご連絡ください！
 
-- 月例会: 第2火曜日 16:00-18:00 (LicenseInfo-SG との合同開催。通例、前半がAutomation-SG, 後半がLicenseInfo-SG)
+- 月例会: 第2火曜日 16:00-18:00 (SBOM-SG との合同開催。通例、前半がAutomation-SG, 後半がSBOM-SG)
 - 当面、MS Teams による Online開催 (別途[ML](https://lists.openchainproject.org/g/japan-sg-tooling)及び[Slack#tooling](https://openchain-japanwg.slack.com/archives/CGHP86Y4T)にて案内済)   
 - それぞれの会合及び運営連絡先については、[グループ紹介](https://openchain-project.github.io/OpenChain-JWG/subgroups/tooling/)をご確認ください。


### PR DESCRIPTION
LicenseInfo-SGという書き方残っていたのに気づいてしまったので。