### PR TITLE
add video link of AMM1005(Kyoto)

### DIFF
--- a/docs/meeting-minutes.md
+++ b/docs/meeting-minutes.md
@@ -7,7 +7,7 @@
 場所: 株式会社ソシオネクスト(京都 丹波口) または Zoom  
 [&#x1f4da; 全体会合紹介チラシ](https://github.com/OpenChain-Project/OpenChain-JWG/blob/master/Meeting-Materials/All-Member-Meeting/20231005/OpenChainJapan%E7%AC%AC29%E5%9B%9E%E5%85%A8%E4%BD%93%E4%BC%9A%E5%90%88%E6%A1%88%E5%86%85.pdf)  
 [&#x1f4da; 議事進行スライド](https://github.com/OpenChain-Project/OpenChain-JWG/blob/master/Meeting-Materials/All-Member-Meeting/20231005/JapanWG-AllMemMtg-Agenda-20231005.pptx)  
-[&#x1f3a5; 録画 ちょっと待ってね]()  
+[&#x1f3a5; 録画](https://www.openchainproject.org/news/2023/10/30/openchain-japan-work-group-2023-10-05-recording)  
 [&#x1f4da; 基調講演（OpenChain 最新動向）](https://github.com/OpenChain-Project/OpenChain-JWG/blob/master/Meeting-Materials/All-Member-Meeting/20231005/OpenChain%20Japan%20Work%20Group%202023-10-05.pptx)  
 [&#x1f4da; OpenChain JWG紹介](https://github.com/OpenChain-Project/OpenChain-JWG/blob/master/Meeting-Materials/All-Member-Meeting/20231005/OpenChain_JWG%E7%B4%B9%E4%BB%8B-20231005.pptx)  
 [&#x1f4da; 株式会社ソシオネクスト：取り組み紹介](https://github.com/OpenChain-Project/OpenChain-JWG/blob/master/Meeting-Materials/All-Member-Meeting/20231005/Socionext%E7%B4%B9%E4%BB%8B%20for%20OpenChain_20230929a.pdf)  


### PR DESCRIPTION
10/5の京都での全体会合の録画が公開されましたので、そちらにリンクを張りました。