### PR TITLE
update for community day 260515

### DIFF
--- a/docs/upcoming-cds.md
+++ b/docs/upcoming-cds.md
@@ -1,5 +1,23 @@
 #### The 35th meeting / The 10th hybrid meeting
 
-三菱電機さん@横浜みなとみらいで7月31日、8月1日に開催された第34回コミュニティデイは無事終了しました。直接会場に足を運んでくださった皆さま、オンラインで視聴してくださった皆さま、ありがとうございました。大盛況で（現地参加の方々に限っても）コロナ禍以前の最大参加者数を越えたのではないかと思います。コミュニティデイを今年度中に少なくとももう一回は開催しようと考えていますので、お楽しみに。/ The 34th Community Day held at Mitsubishi Electric @ Yokohama Minato Mirai on July 31 and August 1 was a success. Thank you to everyone who visited the venue in person and watched online. It was a great success and I think we may have exceeded our maximum number of participants before the Corona Disaster. We are planning to hold at least one more Community Day this year. Please stay tuned.
+少し（かなり？）お待たせしてしまいましたが、OpenChain Japan Community Dayが帰ってきます！今回の目玉は、なんといっても新エグゼクティブディレクター、Maryの就任お披露目です。エグゼクティブディレクターとしての熱い想いに加え、欧州企業のOSPO最前線で培ってきた彼女のバックグラウンドを直接聞ける、またとないチャンスです。「OpenChainって何だろう？」という初参加の方も、どうぞお気軽にお越しください。皆さんのネットワークを広げる場として、ぜひ職場のお仲間も誘って一緒に盛り上がりましょう！ / It's been a little while (okay, maybe quite a while!), but we are thrilled to announce that the OpenChain Japan Community Day is back! This time, we're hosting a very special edition to celebrate the appointment of our new Executive Director, Mary Meixia Wang. Not only will she share her vision and roadmap for the future of OpenChain, but she'll also give us a deep dive into her fascinating background working with OSPOs at major European enterprises. Whether you are a long-time contributor or have never attended an OpenChain event before, you are more than welcome! This is a great opportunity to learn about the cutting edge of OSS governance directly from a global leader. Please feel free to invite your colleagues and friends. Let's get together and make this a fantastic event!
 
-*`looking for past meeting logs?`* → [日本語/Japanese](https://openchain-project.github.io/OpenChain-JWG/meeting-minutes.html), [英語/English](https://openchain-project.github.io/OpenChain-JWG/meeting-minutes_en.html)  
+- 日時 / Date and Time:
+  - 2026年5月15日(金) 13:45-17:30 / May 15, 2026 13:45-17:30(JST)
+- 場所 / Location
+  - リアル会場 / in-person:
+    - ソニーシティ大崎 BRIDGE TERMINAL
+    - https://www.sony.co.jp/recruit/office/osaki/
+  - オンラインでも（一部）同時配信 / Also available (in part) via live stream online
+    - https://zoom-lfx.platform.linuxfoundation.org/meeting/98000226853?password=58260b69-e3ab-49be-a327-defad38c41f3
+
+1. オープニング
+1. Welcome Mary!! 新エグゼクティブディレクター紹介
+1. Case Studies on the EU's OSPO (Mary Meixia Wang)
+1. ネットワーキング
+1. 課題共有とディスカッション(Open Space Technology方式)
+  - Ask the Expert
+  - ディスカッションテーマ(SBOM, CRA, OSPO, Education & FAQなど)
+1. クロージング
+
+*`looking for past meeting logs?`* → [日本語/Japanese](https://openchain-project.github.io/OpenChain-JWG/meeting-minutes.html), [英語/English](https://openchain-project.github.io/OpenChain-JWG/meeting-minutes_en.html)


### PR DESCRIPTION
2026年5月15日(金) のOpenChain Japan Community Dayの案内作成